### PR TITLE
✅ test/ZIP-34 : 알림센터 테스트 코드 구현

### DIFF
--- a/src/main/java/com/zipte/platform/server/application/service/NotificationService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/NotificationService.java
@@ -25,6 +25,10 @@ public class NotificationService implements UserNotificationUseCase {
     @Override
     public boolean checkNewNotification(Long userId) {
         LocalDateTime readAt = timeNotificationPort.getLatestReadAt(userId);
+
+        // 알림 읽음 시간을 현재로 바꾼다.
+        timeNotificationPort.setLatestReadAt(userId);
+
         Notification latest = loadNotificationPort.loadNotificationsAt(userId).orElse(null);
 
         if (latest == null) {

--- a/src/test/java/com/zipte/platform/server/application/service/NotificationServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/NotificationServiceTest.java
@@ -1,0 +1,111 @@
+package com.zipte.platform.server.application.service;
+
+import com.zipte.platform.server.application.out.notification.LoadNotificationPort;
+import com.zipte.platform.server.application.out.notification.TimeNotificationPort;
+import com.zipte.platform.server.domain.notification.PropertyNotificationFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private TimeNotificationPort timeNotificationPort;
+
+    @Mock
+    private LoadNotificationPort loadNotificationPort;
+
+    @InjectMocks
+    private NotificationService sut;
+
+    @Test
+    @DisplayName("[happy] 알림기록 없는 경우 알림 존재 할 때, 조회 테스트")
+    void checkNewNotificationByHappy() {
+        // Given
+        Long userId = 1L;
+        String kaptCode = "kaptCode";
+        var stub = PropertyNotificationFixtures.stub(kaptCode);
+
+        /// 이전에 알림을 조회해본 시간이 X
+        given(timeNotificationPort.getLatestReadAt(userId))
+                .willReturn(null);
+
+        given(loadNotificationPort.loadNotificationsAt(userId))
+                .willReturn(Optional.of(stub));
+
+        // When
+        var result = sut.checkNewNotification(userId);
+
+        // Then
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("[bad] 알림기록 없는 경우 알림 존재 하지 않을 때, 조회 테스트")
+    void checkNewNotificationByBad() {
+        // Given
+        Long userId = 1L;
+
+        given(timeNotificationPort.getLatestReadAt(userId))
+                .willReturn(null);
+
+        given(loadNotificationPort.loadNotificationsAt(userId))
+                .willReturn(Optional.empty());
+
+        // When
+        var result = sut.checkNewNotification(userId);
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("[happy] 알림기록 존재한 경우 알림 존재 할 때, 조회 테스트")
+    void checkNewNotificationByTime() {
+        // Given
+        Long userId = 1L;
+
+        /// 최근 조회한 시간 존재 (1분전)
+        given(timeNotificationPort.getLatestReadAt(userId))
+                .willReturn(LocalDateTime.now().minusMinutes(1));
+
+        given(loadNotificationPort.loadNotificationsAt(userId))
+                .willReturn(Optional.empty());
+
+        // When
+        var result = sut.checkNewNotification(userId);
+
+        // Then
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("[bad] 알림기록 존재한 경우 알림 존재 하지 않을 때, 조회 테스트")
+    void checkNewNotificationByBadTime() {
+        // Given
+        Long userId = 1L;
+
+        /// 최근 조회한 시간 존재 (1분전)
+        given(timeNotificationPort.getLatestReadAt(userId))
+                .willReturn(LocalDateTime.now().minusMinutes(1));
+
+        given(loadNotificationPort.loadNotificationsAt(userId))
+                .willReturn(Optional.empty());
+
+        // When
+        var result = sut.checkNewNotification(userId);
+
+        // Then
+        assertFalse(result);
+    }
+}

--- a/src/test/java/com/zipte/platform/server/application/service/NotificationServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/NotificationServiceTest.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -108,4 +111,29 @@ class NotificationServiceTest {
         // Then
         assertFalse(result);
     }
+
+    @Test
+    @DisplayName("[happy] 알림센터 호출시, 알림 시간 변동")
+    void changeNewNotificationTime() {
+        // Given
+        Long userId = 1L;
+
+        // 이전에 알림을 조회한 시간이 null (처음 조회하는 경우)
+        given(timeNotificationPort.getLatestReadAt(userId))
+                .willReturn(null);
+
+        // 알림이 존재하는 경우, 알림을 조회할 수 있도록 설정
+        var stub = PropertyNotificationFixtures.stub("kaptCode");
+        given(loadNotificationPort.loadNotificationsAt(userId))
+                .willReturn(Optional.of(stub));
+
+        // When
+        sut.checkNewNotification(userId);
+
+        // Then
+        verify(timeNotificationPort, times(1))
+                .setLatestReadAt(any());
+
+    }
+
 }

--- a/src/test/java/com/zipte/platform/server/application/service/task/PropertyNotificationServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/task/PropertyNotificationServiceTest.java
@@ -3,7 +3,7 @@ package com.zipte.platform.server.application.service.task;
 import com.zipte.platform.server.application.out.favorite.FavoritePort;
 import com.zipte.platform.server.application.out.notification.property.DeletePropertyNotificationPort;
 import com.zipte.platform.server.application.out.notification.property.SavePropertyNotificationPort;
-import com.zipte.platform.server.domain.PropertyFixtures;
+import com.zipte.platform.server.domain.notification.PropertyFixtures;
 import com.zipte.platform.server.domain.property.Property;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/zipte/platform/server/application/service/task/PropertyNotificationServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/task/PropertyNotificationServiceTest.java
@@ -1,0 +1,126 @@
+package com.zipte.platform.server.application.service.task;
+
+import com.zipte.platform.server.application.out.favorite.FavoritePort;
+import com.zipte.platform.server.application.out.notification.property.DeletePropertyNotificationPort;
+import com.zipte.platform.server.application.out.notification.property.SavePropertyNotificationPort;
+import com.zipte.platform.server.domain.PropertyFixtures;
+import com.zipte.platform.server.domain.property.Property;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("[Service] 알림 생성 단위 테스트")
+class PropertyNotificationServiceTest {
+
+    @Mock
+    private SavePropertyNotificationPort savePort;
+
+    @Mock
+    private DeletePropertyNotificationPort deletePort;
+
+    @Mock
+    private FavoritePort favoritePort;
+
+
+    @InjectMocks
+    private PropertyNotificationService sut;
+
+    @Test
+    @DisplayName("[bad] 관심 등록한 유저가 없는 경우 알림 생성되지 않음")
+    void createNotification_noFavorites() {
+        // Given
+        String kaptCode = "A10027221";
+        List<Long> users = List.of(); // 아무도 관심 등록 안함
+        Property stub = PropertyFixtures.stub(1L, kaptCode);
+
+        given(favoritePort.loadUserFavoriteByComplexCode(kaptCode))
+                .willReturn(users);
+
+        // When
+        sut.createNotification(stub);
+
+        // Then
+        verify(savePort, never()).saveNotification(any());
+    }
+
+
+    @Test
+    @DisplayName("[bad] 본인 아파트의 매물 추가에 따른 알림 생성되지 않음")
+    void createNotification_bad() {
+
+        // Given
+        String kaptCode = "A10027221";
+        List<Long> users = List.of(1L);
+        Property stub = PropertyFixtures.stubs(1L, kaptCode);
+
+        given(favoritePort.loadUserFavoriteByComplexCode(kaptCode))
+                .willReturn(users);
+
+        // When
+        /// A10027221 매물 추가 로직
+        sut.createNotification(stub);
+
+        // Then
+        verify(savePort, times(0))
+                .saveNotification(any());
+
+    }
+
+    @Test
+    @DisplayName("[happy] 아파트의 매물 추가에 따른 알림 생성")
+    void createNotification_successfully() {
+
+        // Given
+        String kaptCode = "A10027221";
+        List<Long> users = List.of(2L);
+        Property stub = PropertyFixtures.stub(1L, kaptCode);
+
+        given(favoritePort.loadUserFavoriteByComplexCode(kaptCode))
+                .willReturn(users);
+
+        // When
+        /// A10027221 매물 추가 로직
+        sut.createNotification(stub);
+
+        // Then
+        verify(savePort, times(1))
+                .saveNotification(any());
+
+    }
+
+
+    @Test
+    @DisplayName("[happy] 복수의 사용자에게 동일한 매물이 알림으로 전송됨")
+    void createNotification_successfully_multiple() {
+
+        // Given
+        String kaptCode = "A10027221";
+        List<Long> users = List.of(2L,3L);
+        Property stub = PropertyFixtures.stub(1L, kaptCode);
+
+        given(favoritePort.loadUserFavoriteByComplexCode(kaptCode))
+                .willReturn(users);
+
+        // When
+        /// A10027221 매물 추가 로직
+        sut.createNotification(stub);
+
+        // Then
+        verify(savePort, times(2))
+                .saveNotification(any());
+
+    }
+
+
+
+}

--- a/src/test/java/com/zipte/platform/server/domain/PropertyFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/PropertyFixtures.java
@@ -1,0 +1,39 @@
+package com.zipte.platform.server.domain;
+
+import com.zipte.platform.server.domain.property.Property;
+import com.zipte.platform.server.domain.property.PropertyAddress;
+import com.zipte.platform.server.domain.property.PropertySnippet;
+import com.zipte.platform.server.domain.property.PropertyType;
+
+public class PropertyFixtures {
+
+    public static Property stubs(Long ownerId, String kaptCode) {
+        PropertyAddress address = PropertyAddress.of(
+                "경기 성남시 분당구 야탑로 123", // 도로명 주소
+                "101동 202호",                // 상세 주소
+                "13579"                      // 우편번호
+        );
+
+        PropertySnippet snippet = PropertySnippet.of(
+                "장미 동부 아파트",
+                "채광 좋고 조용한 동입니다.",
+                3,  // 방 개수
+                2,  // 욕실 개수
+                2005 // 건축 연도
+        );
+
+        return Property.of(
+                ownerId,
+                PropertyType.APARTMENT,
+                address,
+                snippet,
+                250000000L, // 가격
+                kaptCode
+        );
+    }
+
+    public static Property stub(Long userId, String kaptCode) {
+        return stubs(userId, kaptCode);
+    }
+}
+

--- a/src/test/java/com/zipte/platform/server/domain/notification/PropertyFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/notification/PropertyFixtures.java
@@ -1,4 +1,4 @@
-package com.zipte.platform.server.domain;
+package com.zipte.platform.server.domain.notification;
 
 import com.zipte.platform.server.domain.property.Property;
 import com.zipte.platform.server.domain.property.PropertyAddress;

--- a/src/test/java/com/zipte/platform/server/domain/notification/PropertyNotificationFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/notification/PropertyNotificationFixtures.java
@@ -1,0 +1,18 @@
+package com.zipte.platform.server.domain.notification;
+
+import java.time.LocalDateTime;
+
+public class PropertyNotificationFixtures {
+    public static PropertyNotification stub(String kaptCode) {
+        return PropertyNotification.builder()
+                .id("id")
+                .kaptCode(kaptCode)
+                .userId(2L)
+                .price(100000)
+                .createdAt(LocalDateTime.now())
+                .occurredAt(LocalDateTime.now())
+                .lastUpdatedAt(LocalDateTime.now())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->


## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 알림 확인 시 사용자의 최근 알림 읽음 시간이 즉시 갱신됩니다.

- **테스트**
  - 알림 서비스와 관련된 다양한 시나리오를 검증하는 테스트가 추가되었습니다.
  - 부동산 알림 생성 로직에 대한 테스트가 추가되었습니다.
  - 테스트용 부동산 및 부동산 알림 객체를 손쉽게 생성할 수 있는 테스트 픽스처가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->