### PR TITLE
♻️ refactor/ZIP-45 : 위치기반 거주지 인증 

### DIFF
--- a/src/main/java/com/zipte/platform/core/response/ErrorCode.java
+++ b/src/main/java/com/zipte/platform/core/response/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     /// 부동산 관련
     NOT_ESTATE(2000, HttpStatus.NOT_FOUND, "해당하는 부동산이 존재하지 않습니다."),
     NOT_ESTATE_IN_YOUR_AREA(2001, HttpStatus.BAD_REQUEST, "1KM 반경 내에 해당 부동산이 존재하지 않습니다."),
+    NOT_DATE(2002, HttpStatus.BAD_REQUEST, "오늘 이후의 구매 일정은 설정할 수 없습니다."),
+    BAD_REQUEST_ESTATE(400, HttpStatus.BAD_REQUEST, "이미 등록된 아파트를 등록할 수 없습니다,."),
 
     /// 리뷰 관련
     NOT_REVIEW(5000, HttpStatus.NOT_FOUND, "해당하는 리뷰가 존재하지 않습니다."),

--- a/src/main/java/com/zipte/platform/server/adapter/in/web/dto/request/EstateOwnershipRequest.java
+++ b/src/main/java/com/zipte/platform/server/adapter/in/web/dto/request/EstateOwnershipRequest.java
@@ -1,5 +1,7 @@
 package com.zipte.platform.server.adapter.in.web.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,15 +11,21 @@ import java.time.LocalDateTime;
 @Builder
 public class EstateOwnershipRequest {
 
+    @NotNull(message = "유저 ID는 필수입니다.")
     private Long userId;
 
+    @NotNull(message = "아파트 코드(kaptCode)는 필수입니다.")
+    @Size(min = 1, message = "아파트 코드는 비어 있을 수 없습니다.")
     private String kaptCode;
 
     /// 사용자의 현위치
+    @NotNull(message = "경도는 필수입니다.")
     private Double longitude;
+
+    @NotNull(message = "위도는 필수입니다.")
     private Double latitude;
 
-    // 아파트의 소유 날짜
+    @NotNull(message = "구매 날짜는 필수입니다.")
     private LocalDateTime boughtAt;
 
 }

--- a/src/main/java/com/zipte/platform/server/application/service/EstateOwnershipService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/EstateOwnershipService.java
@@ -29,6 +29,10 @@ public class EstateOwnershipService implements EstateOwnershipUseCase {
     private final UserPort loadUserPort;
     private final LoadEstatePort loadEstatePort;
 
+    private final double EARTH_RADIUS_KM = 6373;
+    private final double ONE_KM_IN_RADIANS = 1 / EARTH_RADIUS_KM / 2;
+
+
     @Override
     public EstateOwnership createOwnership(EstateOwnershipRequest request) {
 
@@ -47,9 +51,7 @@ public class EstateOwnershipService implements EstateOwnershipUseCase {
         /// 현 위치와 아파트 위치와의 비교 예외처리
 
         // 현 위치 반경 1KM 조회에 아파트 존재하는지 체크
-        List<Estate> list = loadEstatePort.loadEstatesNearBy(request.getLongitude(), request.getLatitude(), 1 / 6373 / 2);
-
-        log.info("Load estates nearby : {}", list.toString());
+        List<Estate> list = loadEstatePort.loadEstatesNearBy(request.getLongitude(), request.getLatitude(), ONE_KM_IN_RADIANS);
 
         boolean hasKaptCode = list.stream()
                 .anyMatch(f -> f.getKaptCode().equals(request.getKaptCode()));

--- a/src/main/java/com/zipte/platform/server/application/service/EstateOwnershipService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/EstateOwnershipService.java
@@ -6,6 +6,7 @@ import com.zipte.platform.server.application.in.estateOwnership.EstateOwnershipU
 import com.zipte.platform.server.application.out.estate.LoadEstatePort;
 import com.zipte.platform.server.application.out.estateOwnership.EstateOwnerShipPort;
 import com.zipte.platform.server.application.out.user.UserPort;
+import com.zipte.platform.server.application.service.exception.AlreadyExistingEstateException;
 import com.zipte.platform.server.application.service.exception.NotExistingEstateInYourAreaException;
 import com.zipte.platform.server.domain.estate.Estate;
 import com.zipte.platform.server.domain.estateOwnership.EstateOwnership;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -48,8 +50,18 @@ public class EstateOwnershipService implements EstateOwnershipUseCase {
             throw new NoSuchElementException(ErrorCode.NOT_ESTATE.getMessage());
         }
 
-        /// 현 위치와 아파트 위치와의 비교 예외처리
+        /// 이미 등록했는지 여부 체크
+        boolean existCheck = port.loadOwnershipByUser(request.getUserId(), request.getKaptCode());
+        if (existCheck) {
+            throw new AlreadyExistingEstateException(ErrorCode.BAD_REQUEST_ESTATE.getMessage());
+        }
 
+        /// 구매 날짜 예외처리
+        if (request.getBoughtAt().isAfter(LocalDateTime.now())) {
+            throw new IllegalArgumentException(ErrorCode.NOT_DATE.getMessage());
+        }
+
+        /// 현 위치와 아파트 위치와의 비교 예외처리
         // 현 위치 반경 1KM 조회에 아파트 존재하는지 체크
         List<Estate> list = loadEstatePort.loadEstatesNearBy(request.getLongitude(), request.getLatitude(), ONE_KM_IN_RADIANS);
 

--- a/src/main/java/com/zipte/platform/server/application/service/exception/AlreadyExistingEstateException.java
+++ b/src/main/java/com/zipte/platform/server/application/service/exception/AlreadyExistingEstateException.java
@@ -1,0 +1,7 @@
+package com.zipte.platform.server.application.service.exception;
+
+public class AlreadyExistingEstateException extends RuntimeException {
+    public AlreadyExistingEstateException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/zipte/platform/server/application/service/EstateOwnershipServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/EstateOwnershipServiceTest.java
@@ -1,0 +1,196 @@
+package com.zipte.platform.server.application.service;
+
+import com.zipte.platform.server.adapter.in.web.dto.request.EstateOwnershipRequest;
+import com.zipte.platform.server.application.out.estate.LoadEstatePort;
+import com.zipte.platform.server.application.out.estateOwnership.EstateOwnerShipPort;
+import com.zipte.platform.server.application.out.user.UserPort;
+import com.zipte.platform.server.application.service.exception.AlreadyExistingEstateException;
+import com.zipte.platform.server.application.service.exception.NotExistingEstateInYourAreaException;
+import com.zipte.platform.server.domain.estate.Estate;
+import com.zipte.platform.server.domain.estateOwnership.EstateOwnership;
+import com.zipte.platform.server.domain.review.EstateFixtures;
+import com.zipte.platform.server.domain.review.EstateOwnerShipFixtures;
+import org.junit.Assert;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EstateOwnershipServiceTest {
+
+    private final double EARTH_RADIUS_KM = 6373;
+    private final double ONE_KM_IN_RADIANS = 1 / EARTH_RADIUS_KM / 2;
+
+    @Mock
+    private EstateOwnerShipPort port;
+
+    @Mock
+    private LoadEstatePort loadEstatePort;
+
+    @Mock
+    private UserPort loadUserPort;
+
+    @InjectMocks
+    private EstateOwnershipService sut;
+
+    @Test
+    @DisplayName("[error] TC - 유저가 없는 경우")
+    public void badRequest_user() {
+
+        // Given
+        var request = createRequest(00.00, 00.00);
+
+        // When
+        given(loadUserPort.checkExistingById(anyLong())).willReturn(false);
+
+        // Then
+        Assert.assertThrows(NoSuchElementException.class,
+                () -> sut.createOwnership(request));
+
+    }
+
+
+    @Test
+    @DisplayName("[error] TC - 아파트 코드가 없는 경운")
+    public void badRequest_code() {
+
+        // Given
+        var request = createRequest(00.00, 00.00);
+
+        // When
+        given(loadUserPort.checkExistingById(anyLong())).willReturn(true);
+        given(loadEstatePort.checkExistingByCode(any())).willReturn(false);
+
+        // Then
+        Assert.assertThrows(NoSuchElementException.class,
+                () -> sut.createOwnership(request));
+
+
+    }
+
+    @Test
+    @DisplayName("[happy] TC - 원하는 아파트 반경 1KM에 유저가 존재하는 경우 인증 가능")
+    public void createOwnerShipBy1KM() {
+
+        // Given
+        var request = createRequest(00.00, 00.00);
+
+        given(loadUserPort.checkExistingById(anyLong())).willReturn(true);
+
+        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+
+        Estate stub = EstateFixtures.stub();
+        given(loadEstatePort.loadEstatesNearBy(request.getLongitude(), request.getLatitude(), ONE_KM_IN_RADIANS))
+                .willReturn(List.of(stub));
+
+        given(port.saveOwnership(any(EstateOwnership.class)))
+                .willReturn(EstateOwnerShipFixtures.stub(request.getUserId(), request.getKaptCode(), request.getBoughtAt()));
+
+        // When
+        var result = sut.createOwnership(request);
+
+        // Then
+        then(result)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("userId", 1L)
+                .hasFieldOrPropertyWithValue("kaptCode", "kaptCode");
+    }
+
+    @Test
+    @DisplayName("[edge] TC - 원하는 아파트 반경 1KM 외부에 유저가 존재하는 경우 인증 불가")
+    public void createOwnerShipBy1KMOutOfRange() {
+
+        // Given
+        var request = createRequest(00.00, 00.00);
+
+
+        // Mocking 서비스 메서드 호출
+        given(loadUserPort.checkExistingById(anyLong())).willReturn(true);
+
+        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+
+
+        // When & Then
+        Assert.assertThrows(NotExistingEstateInYourAreaException.class,
+                () -> sut.createOwnership(request));
+    }
+
+
+    @Test
+    @DisplayName("[edge] TC - 인증 가능 케이스에서 오늘 이후의 날짜로 구매 날짜를 지정 IllegalStateException 발생")
+    public void createOwnerShipBy1KM_dateError() {
+
+        // Given
+        var request = createRequest(00.00, 00.00, LocalDateTime.now().plusDays(3));
+
+        given(loadUserPort.checkExistingById(anyLong()))
+                .willReturn(true);
+        given(loadEstatePort.checkExistingByCode(any()))
+                .willReturn(true);
+
+        // When & Then
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> sut.createOwnership(request));
+
+
+    }
+
+
+
+    private EstateOwnershipRequest createRequest(double lat, double lon) {
+        return EstateOwnershipRequest.builder()
+                .userId(1L)
+                .kaptCode("kaptCode")
+                .latitude(lat)
+                .longitude(lon)
+                .boughtAt(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    private EstateOwnershipRequest createRequest(double lat, double lon, LocalDateTime boughtAt) {
+        return EstateOwnershipRequest.builder()
+                .userId(1L)
+                .kaptCode("kaptCode")
+                .latitude(lat)
+                .longitude(lon)
+                .boughtAt(boughtAt)
+                .build();
+    }
+
+    @Test
+    @DisplayName("[edge] TC - 이미 인증된 아파트에 대해 또 인증 요청 시 예외 발생")
+    void duplicateOwnershipRequest() {
+        // Given
+        var request = createRequest(00.00, 00.00);
+
+        given(loadUserPort.checkExistingById(anyLong())).willReturn(true);
+        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+
+        // 중복 존재 시나리오
+        given(port.loadOwnershipByUser(anyLong(), any()))
+                .willReturn(true);
+
+        // When & Then
+        Assert.assertThrows(AlreadyExistingEstateException.class,
+                () -> sut.createOwnership(request));
+    }
+
+
+
+
+
+
+
+}

--- a/src/test/java/com/zipte/platform/server/domain/review/EstateFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/review/EstateFixtures.java
@@ -1,0 +1,26 @@
+package com.zipte.platform.server.domain.review;
+
+import com.zipte.platform.server.domain.estate.Estate;
+import com.zipte.platform.server.domain.estate.Location;
+
+import java.util.Arrays;
+
+public class EstateFixtures {
+
+    public static Estate stub() {
+
+        Location location = Location.builder()
+                .type("Point")
+                .coordinates(Arrays.asList(
+                        127.1280,  // 경도
+                        37.4116)   // 위도
+                )
+                .build();
+
+        return Estate.builder()
+                .kaptCode("kaptCode")
+                .location(location)
+                .build();
+    }
+
+}

--- a/src/test/java/com/zipte/platform/server/domain/review/EstateOwnerShipFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/review/EstateOwnerShipFixtures.java
@@ -1,0 +1,24 @@
+package com.zipte.platform.server.domain.review;
+
+import com.zipte.platform.server.domain.estateOwnership.EstateOwnership;
+
+import java.time.LocalDateTime;
+
+public class EstateOwnerShipFixtures {
+
+    private static EstateOwnership estateOwnership(Long userId, String kaptCode, LocalDateTime boughtAt) {
+        return EstateOwnership.builder()
+                .id(1L)
+                .userId(userId)
+                .kaptCode(kaptCode)
+                .boughtAt(boughtAt)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static EstateOwnership stub(Long userId, String kaptCode, LocalDateTime boughtAt) {
+        return estateOwnership(userId, kaptCode, boughtAt);
+    }
+
+}


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 위치기반 거주지 인증 예외처리 코드 추가
- 테스트 코드 추가

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="810" alt="image" src="https://github.com/user-attachments/assets/b68c6437-8efa-4004-b92a-6938283dcd18" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
ZIP-45

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 부동산 소유권 등록 요청 시 필수 입력값 검증이 추가되었습니다. (사용자 ID, 아파트 코드, 위도, 경도, 구매일)
    - 이미 등록된 아파트를 중복 등록하거나, 미래 날짜로 구매일을 입력할 경우 각각의 오류 메시지가 제공됩니다.

- **버그 수정**
    - 소유권 등록 시 중복 등록 및 잘못된 구매일 입력에 대한 예외 처리가 강화되었습니다.

- **테스트**
    - 부동산 소유권 등록 서비스에 대한 단위 테스트가 추가되었습니다.
    - 테스트용 부동산 및 소유권 객체 생성 도우미가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->