### PR TITLE
✅ test/ZIP-57 : 아파트에 대한 리뷰 생성 테스트

### DIFF
--- a/src/main/java/com/zipte/platform/core/response/ErrorCode.java
+++ b/src/main/java/com/zipte/platform/core/response/ErrorCode.java
@@ -36,7 +36,9 @@ public enum ErrorCode {
 
     /// 리뷰 관련
     NOT_REVIEW(5000, HttpStatus.NOT_FOUND, "해당하는 리뷰가 존재하지 않습니다."),
-    BAD_REQUEST_REVIEW(5001, HttpStatus.BAD_REQUEST, "실거주자 인증이 되지 않은 유저입니다.");
+    BAD_REQUEST_DELETE_REVIEW(5001, HttpStatus.BAD_REQUEST, "본인이 등록하지 않은 리뷰를 삭제할 수 없습니다."),
+    BAD_REQUEST_DUPLICATE_REVIEW(5001, HttpStatus.BAD_REQUEST, "이미 존재하는 리뷰가 있습니다. 수정을 진행해주세요"),
+    BAD_REQUEST_REVIEW(5002, HttpStatus.BAD_REQUEST, "실거주자 인증이 되지 않은 유저입니다.");
 
 
     private final Integer code;

--- a/src/main/java/com/zipte/platform/server/adapter/out/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/zipte/platform/server/adapter/out/ReviewPersistenceAdapter.java
@@ -59,7 +59,17 @@ public class ReviewPersistenceAdapter implements LoadReviewPort, SaveReviewPort,
     }
 
     @Override
-    public void removeReview(Review review) {
-        repository.deleteById(review.getId());
+    public boolean checkReviewByIdAndUserId(Long reviewId, Long userId) {
+        return repository.existsByIdAndUserId(reviewId, userId);
+    }
+
+    @Override
+    public boolean checkReviewByUserIdAndKaptCode(Long reviewId, String kaptCode) {
+        return repository.existsByUserIdAndKaptCode(reviewId, kaptCode);
+    }
+
+    @Override
+    public void removeReview(Long id) {
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/com/zipte/platform/server/adapter/out/jpa/review/ReviewJpaRepository.java
+++ b/src/main/java/com/zipte/platform/server/adapter/out/jpa/review/ReviewJpaRepository.java
@@ -16,4 +16,11 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long
 
     // 아파트별 리뷰 (전체 평점 높은 순, 페이징)
     Page<ReviewJpaEntity> findByKaptCodeOrderBySnippetOverallDesc(String kaptCode, Pageable pageable);
+
+
+    /// 삭제를 위해서 유저, id가 동일한 것 가져오기
+    boolean existsByIdAndUserId(Long id, Long userId);
+
+    boolean existsByUserIdAndKaptCode(Long userId, String kaptCode);
+
 }

--- a/src/main/java/com/zipte/platform/server/application/in/review/DeleteReviewUseCase.java
+++ b/src/main/java/com/zipte/platform/server/application/in/review/DeleteReviewUseCase.java
@@ -1,14 +1,12 @@
 package com.zipte.platform.server.application.in.review;
 
-import com.zipte.platform.server.domain.review.Review;
-
 public interface DeleteReviewUseCase {
 
     /*
        리뷰를 삭제하는 유즈케이스입니다.
      */
 
-    void removeReview(Review review);
+    void removeReview(Long reviewId, Long userId);
 
 
 }

--- a/src/main/java/com/zipte/platform/server/application/out/review/LoadReviewPort.java
+++ b/src/main/java/com/zipte/platform/server/application/out/review/LoadReviewPort.java
@@ -19,4 +19,9 @@ public interface LoadReviewPort {
 
     // 높은 평점순 리뷰 가져오기
     Page<Review> getReviewsByRating(String aptId, Pageable pageable);
+
+    /// 일치 여부
+    boolean checkReviewByIdAndUserId(Long reviewId, Long userId);
+
+    boolean checkReviewByUserIdAndKaptCode(Long reviewId, String kaptCode);
 }

--- a/src/main/java/com/zipte/platform/server/application/out/review/RemoveReviewPort.java
+++ b/src/main/java/com/zipte/platform/server/application/out/review/RemoveReviewPort.java
@@ -1,8 +1,8 @@
 package com.zipte.platform.server.application.out.review;
 
-import com.zipte.platform.server.domain.review.Review;
 
 public interface RemoveReviewPort {
 
-    void removeReview(Review review);
+    void removeReview(Long id);
+
 }

--- a/src/main/java/com/zipte/platform/server/application/service/ReviewService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/ReviewService.java
@@ -76,6 +76,11 @@ public class ReviewService implements CreateReviewUseCase, GetReviewUseCase, Del
     // 최신순
     @Override
     public Page<Review> getReviews(String aptId, Pageable pageable) {
+        /// 아파트에 대한 예외처리
+        boolean checked = loadEstatePort.checkExistingByCode(aptId);
+        if (!checked) {
+            throw new NoSuchElementException(ErrorCode.NOT_ESTATE.getMessage());
+        }
 
         return loadReviewPort.getReviews(aptId, pageable);
     }

--- a/src/main/java/com/zipte/platform/server/application/service/ReviewService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/ReviewService.java
@@ -44,6 +44,11 @@ public class ReviewService implements CreateReviewUseCase, GetReviewUseCase, Del
             throw new NoSuchElementException(ErrorCode.NOT_USER.getMessage());
         }
 
+        /// 이미 작성한 리뷰가 있는 지 체크
+        boolean checkedDuplicate = loadReviewPort.checkReviewByUserIdAndKaptCode(request.getUserId(), request.getKaptCode());
+        if (checkedDuplicate) {
+            throw new IllegalStateException(ErrorCode.BAD_REQUEST_DUPLICATE_REVIEW.getMessage());
+        }
 
         ///  아파트 존재 여부 예외처리
         boolean existingEstate = loadEstatePort.checkExistingByCode(request.getKaptCode());
@@ -89,6 +94,12 @@ public class ReviewService implements CreateReviewUseCase, GetReviewUseCase, Del
     @Override
     public Page<Review> getReviewsByRating(String aptId, Pageable pageable) {
 
+        /// 아파트에 대한 예외처리
+        boolean checked = loadEstatePort.checkExistingByCode(aptId);
+        if (!checked) {
+            throw new NoSuchElementException(ErrorCode.NOT_ESTATE.getMessage());
+        }
+
         return loadReviewPort.getReviewsByRating(aptId, pageable);
     }
 
@@ -100,9 +111,21 @@ public class ReviewService implements CreateReviewUseCase, GetReviewUseCase, Del
     }
 
     @Override
-    public void removeReview(Review review) {
+    public void removeReview(Long reviewId, Long userId) {
 
-        removeReviewPort.removeReview(review);
+        /// 유저 예외처리
+        boolean checked = loadUserPort.checkExistingById(userId);
+        if (!checked) {
+            throw new NoSuchElementException(ErrorCode.NOT_USER.getMessage());
+        }
+
+        /// 해당 유저와 리뷰가 일치하는지 테스트
+        boolean checked2 = loadReviewPort.checkReviewByIdAndUserId(reviewId, userId);
+        if (!checked2) {
+            throw new IllegalStateException(ErrorCode.BAD_REQUEST_DELETE_REVIEW.getMessage());
+        }
+
+        removeReviewPort.removeReview(reviewId);
     }
 
 

--- a/src/test/java/com/zipte/platform/server/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/ReviewServiceTest.java
@@ -1,5 +1,6 @@
 package com.zipte.platform.server.application.service;
 
+import com.zipte.platform.core.response.ErrorCode;
 import com.zipte.platform.server.adapter.in.web.dto.request.ReviewRequest;
 import com.zipte.platform.server.application.out.estate.LoadEstatePort;
 import com.zipte.platform.server.application.out.estateOwnership.EstateOwnerShipPort;
@@ -12,6 +13,7 @@ import com.zipte.platform.server.domain.review.ReviewFixtures;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,179 +26,373 @@ import org.springframework.data.domain.Pageable;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("[Service] 리뷰 서비스 단위 테스트")
 class ReviewServiceTest {
 
-    @Mock private SaveReviewPort saveReviewPort;
-    @Mock private LoadReviewPort loadReviewPort;
-    @Mock private RemoveReviewPort removeReviewPort;
-    @Mock private EstateOwnerShipPort ownershipPort;
-    @Mock private UserPort loadUserPort;
-    @Mock private LoadEstatePort loadEstatePort;
+    @Mock
+    private SaveReviewPort saveReviewPort;
+    @Mock
+    private LoadReviewPort loadReviewPort;
+    @Mock
+    private RemoveReviewPort removeReviewPort;
+    @Mock
+    private EstateOwnerShipPort ownershipPort;
+    @Mock
+    private UserPort loadUserPort;
+    @Mock
+    private LoadEstatePort loadEstatePort;
 
     @InjectMocks
     private ReviewService sut;
 
-    @Test
-    @DisplayName("[happy] 실거주민이 유효한 별점을 남긴다")
-    void createReview() {
 
-        // Given
-        var reviewRequest = ReviewRequest.builder()
-                .userId(1L)
-                .kaptCode("kaptCode")
-                .title("title")
-                .content("content")
-                .apartmentManagement(1)
-                .environment(1)
-                .livingEnvironment(1)
-                .transport(1)
-                .build();
+    @Nested()
+    @DisplayName("리뷰 생성 관련 테스트")
+    class SaveReview {
 
-        Review review = ReviewFixtures.stub(1L);
-        given(loadUserPort.checkExistingById(1L)).willReturn(true);
-        given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(true);
-        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
 
-        given(saveReviewPort.saveReview(any())).willReturn(review);
+        @Test
+        @DisplayName("[happy] 실거주민이 유효한 별점을 남긴다")
+        void createReview() {
 
-        // When
-        var result = sut.createReview(reviewRequest);
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(1)
+                    .environment(1)
+                    .livingEnvironment(1)
+                    .transport(1)
+                    .build();
 
-        // Then
-        then(result)
-                .isNotNull()
-                .hasFieldOrPropertyWithValue("id", review.getId())
-                .hasFieldOrPropertyWithValue("kaptCode", review.getKaptCode())
-                .hasFieldOrPropertyWithValue("snippet.title", review.getSnippet().getTitle())
-                .hasFieldOrPropertyWithValue("snippet.content", review.getSnippet().getContent())
-                .hasFieldOrPropertyWithValue("snippet.apartmentManagement", review.getSnippet().getApartmentManagement())
-                .hasFieldOrPropertyWithValue("statistics.viewCount", review.getStatistics().getViewCount());
+            Review review = ReviewFixtures.stub(1L);
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+            given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(true);
+            given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
 
+            given(saveReviewPort.saveReview(any())).willReturn(review);
+
+            // When
+            var result = sut.createReview(reviewRequest);
+
+            // Then
+            then(result)
+                    .isNotNull()
+                    .hasFieldOrPropertyWithValue("id", review.getId())
+                    .hasFieldOrPropertyWithValue("kaptCode", review.getKaptCode())
+                    .hasFieldOrPropertyWithValue("snippet.title", review.getSnippet().getTitle())
+                    .hasFieldOrPropertyWithValue("snippet.content", review.getSnippet().getContent())
+                    .hasFieldOrPropertyWithValue("snippet.apartmentManagement", review.getSnippet().getApartmentManagement())
+                    .hasFieldOrPropertyWithValue("statistics.viewCount", review.getStatistics().getViewCount());
+
+        }
+
+        @Test
+        @DisplayName("[edge] 동일 유저가 동일 아파트에 이미 리뷰를 작성한 경우 예외 발생")
+        void createReviewWhenAlreadyExists() {
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("중복리뷰")
+                    .content("이미 작성한 리뷰입니다")
+                    .apartmentManagement(2)
+                    .environment(2)
+                    .livingEnvironment(2)
+                    .transport(2)
+                    .build();
+
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+
+            // 이미 작성된 리뷰가 있다고 가정
+            given(loadReviewPort.checkReviewByUserIdAndKaptCode(1L, "kaptCode"))
+                    .willReturn(true);
+
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(ErrorCode.BAD_REQUEST_DUPLICATE_REVIEW.getMessage());
+
+        }
+
+
+        @Test
+        @DisplayName("[edge] 실거주민이 0점을 남긴다")
+        void createReviewInRating0() {
+
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(0)
+                    .environment(1)
+                    .livingEnvironment(0)
+                    .transport(1)
+                    .build();
+
+            // When
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+            given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+            given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(true);
+
+
+            // Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("[edge] 리뷰 총점이 0.5로 너무 낮은 경우 예외 발생")
+        void createReviewInRating_Under1() {
+
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(0)
+                    .environment(1)
+                    .livingEnvironment(0)
+                    .transport(1)
+                    .build();
+
+            // When
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+            given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+            given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(true);
+
+            // Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("[edge] 비거주민이 별점을 남기려 한다.")
+        void createReviewNoUserId() {
+
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(0)
+                    .environment(1)
+                    .livingEnvironment(0)
+                    .transport(1)
+                    .build();
+
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+            given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
+            given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(false); // 유저가 가지고 있지 않다고 가정
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("[error] 존재하지않는 아파트에 리뷰를 남기려 한다.")
+        void createReviewNoKaptCode() {
+
+            // Given
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(1L)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(0)
+                    .environment(1)
+                    .livingEnvironment(0)
+                    .transport(1)
+                    .build();
+
+            given(loadUserPort.checkExistingById(1L)).willReturn(true);
+            given(loadEstatePort.checkExistingByCode(any())).willReturn(false);
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(NoSuchElementException.class);
+
+        }
+
+
+        // Error
+        @Test
+        @DisplayName("[error] 존재하지 않는 유저가 리뷰를 남기려는 경우")
+        void createReviewError_user() {
+
+            // Given
+
+            Long userId = 1L;
+            var reviewRequest = ReviewRequest.builder()
+                    .userId(userId)
+                    .kaptCode("kaptCode")
+                    .title("title")
+                    .content("content")
+                    .apartmentManagement(0)
+                    .environment(1)
+                    .livingEnvironment(0)
+                    .transport(1)
+                    .build();
+
+            // When
+            given(loadUserPort.checkExistingById(userId))
+                    .willReturn(false);
+
+
+            // Then
+            Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
     }
 
-    @Test
-    @DisplayName("[bad] 실거주민이 0점을 남긴다")
-    void createReviewInRating0() {
 
-        // Given
-        var reviewRequest = ReviewRequest.builder()
-                .userId(1L)
-                .kaptCode("kaptCode")
-                .title("title")
-                .content("content")
-                .apartmentManagement(0)
-                .environment(1)
-                .livingEnvironment(0)
-                .transport(1)
-                .build();
+    @Nested()
+    @DisplayName("리뷰 조회 관련 테스트")
+    class LoadReview {
+        /// 조회
+        @Test
+        @DisplayName(("[happy] 아파트에 대한 리뷰가 있는 경우, 정상 조회된다."))
+        void loadReviewByCode_happy() {
 
-        // When
-        given(loadUserPort.checkExistingById(1L)).willReturn(true);
-        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
-        given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(true);
+            // Given
+            String kaptCode = "kaptCode";
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Review> stubs = ReviewFixtures.pagedStubs(pageable);
+
+            given(loadEstatePort.checkExistingByCode(kaptCode))
+                    .willReturn(true);
+            given(loadReviewPort.getReviews(kaptCode, pageable))
+                    .willReturn(stubs);
+
+            // When
+            Page<Review> reviews = sut.getReviews(kaptCode, pageable);
+
+            // Then
+            BDDAssertions.then(reviews.getContent())
+                    .hasSize(2);
+        }
+
+        @Test
+        @DisplayName(("[edge] 아파트에 대한 리뷰가 없는 경우, 0개의 리뷰가 조회된다.."))
+        void loadReviewByCode_bad() {
+
+            // Given
+            String kaptCode = "kaptCode";
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(loadEstatePort.checkExistingByCode(kaptCode)).willReturn(true);
+            given(loadReviewPort.getReviews(kaptCode, pageable))
+                    .willReturn(Page.empty());
+            // When
+            Page<Review> reviews = sut.getReviews(kaptCode, pageable);
+
+            // Then
+            BDDAssertions.then(reviews.getContent())
+                    .hasSize(0);
+        }
+
+        @Test
+        @DisplayName("[error] 존재하지 않는 아파트 코드로 조회하면 예외 발생")
+        void loadReviewByCode_error() {
+
+            // Given
+            String kaptCode = "kaptCode";
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // When
+            given(loadEstatePort.checkExistingByCode(kaptCode))
+                    .willReturn(false);
+
+            // Then
+            Assertions.assertThatThrownBy(() -> sut.getReviews(kaptCode, pageable))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessage(ErrorCode.NOT_ESTATE.getMessage());
 
 
-        // Then
-        Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
-                .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
-    @Test
-    @DisplayName("[bad] 비거주민이 별점을 남기려 한다.")
-    void createReviewNoUserId() {
+    @Nested()
+    @DisplayName("리뷰 삭제 관련 테스트")
+    class RemoveReview {
+        /// 삭제
+        @Test
+        @DisplayName("[happy] 리뷰의 id와 작성한 유저의 id가 동일하다면, 리뷰를 삭제할 수 있다.")
+        void deleteReviews_happy() {
 
-        // Given
-        var reviewRequest = ReviewRequest.builder()
-                .userId(1L)
-                .kaptCode("kaptCode")
-                .title("title")
-                .content("content")
-                .apartmentManagement(0)
-                .environment(1)
-                .livingEnvironment(0)
-                .transport(1)
-                .build();
+            // Given
+            Long id = 3L;
+            Long userId = 1L;
 
-        given(loadUserPort.checkExistingById(1L)).willReturn(true);
-        given(loadEstatePort.checkExistingByCode(any())).willReturn(true);
-        given(ownershipPort.loadOwnershipByUser(any(), any())).willReturn(false); // 유저가 가지고 있지 않다고 가정
+            given(loadUserPort.checkExistingById(userId))
+                    .willReturn(true);
 
-        // When & Then
-        Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
-                .isInstanceOf(IllegalStateException.class);
+            given(loadReviewPort.checkReviewByIdAndUserId(id, userId))
+                    .willReturn(true);
+
+            // When
+            sut.removeReview(id, userId);
+
+            // Then
+            verify(removeReviewPort).removeReview(id);
+
+        }
+
+        @Test
+        @DisplayName("[edge] 리뷰의 id와 작성한 유저의 id가 동일하지 않을 때, 리뷰를 삭제할 수 없다.")
+        void deleteReviews_edge() {
+
+            // Given
+            Long id = 3L;
+            Long attackerId = 1L;
+
+            given(loadUserPort.checkExistingById(attackerId))
+                    .willReturn(true);
+
+            given(loadReviewPort.checkReviewByIdAndUserId(id, attackerId))
+                    .willReturn(false);
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> sut.removeReview(id, attackerId))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage(ErrorCode.BAD_REQUEST_DELETE_REVIEW.getMessage());
+
+
+        }
+
+
+        @Test
+        @DisplayName("[error] 존재하지 않는 유저가 삭제 시도")
+        void deleteReviews_error() {
+
+            // Given
+            Long id = 3L;
+            Long userId = 10L;
+
+            given(loadUserPort.checkExistingById(userId))
+                    .willReturn(false);
+
+            // When & Then
+            Assertions.assertThatThrownBy(() -> sut.removeReview(id, userId))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessage(ErrorCode.NOT_USER.getMessage());
+
+        }
     }
-
-    @Test
-    @DisplayName("[bad] 존재하지않는 아파트에 리뷰를 남기려 한다.")
-    void createReviewNoKaptCode() {
-
-        // Given
-        var reviewRequest = ReviewRequest.builder()
-                .userId(1L)
-                .kaptCode("kaptCode")
-                .title("title")
-                .content("content")
-                .apartmentManagement(0)
-                .environment(1)
-                .livingEnvironment(0)
-                .transport(1)
-                .build();
-
-        given(loadUserPort.checkExistingById(1L)).willReturn(true);
-        given(loadEstatePort.checkExistingByCode(any())).willReturn(false);
-
-        // When & Then
-        Assertions.assertThatThrownBy(() -> sut.createReview(reviewRequest))
-                .isInstanceOf(NoSuchElementException.class);
-
-    }
-
-    @Test
-    @DisplayName(("[happy] 아파트에 대한 리뷰가 있는 경우, 정상 조회된다."))
-    void loadReviewByCode_happy() {
-
-        // Given
-        String kaptCode = "kaptCode";
-        Pageable pageable = PageRequest.of(0, 10);
-
-        Page<Review> stubs = ReviewFixtures.pagedStubs(pageable);
-
-        given(loadEstatePort.checkExistingByCode(kaptCode))
-                .willReturn(true);
-        given(loadReviewPort.getReviews(kaptCode, pageable))
-                .willReturn(stubs);
-
-        // When
-        Page<Review> reviews = sut.getReviews(kaptCode, pageable);
-
-        // Then
-        BDDAssertions.then(reviews.getContent())
-                .hasSize(2);
-    }
-
-    @Test
-    @DisplayName(("[edge] 아파트에 대한 리뷰가 없는 경우, 0개의 리뷰가 조회된다.."))
-    void loadReviewByCode_bad() {
-
-        // Given
-        String kaptCode = "kaptCode";
-        Pageable pageable = PageRequest.of(0, 10);
-
-        given(loadEstatePort.checkExistingByCode(kaptCode)).willReturn(true);
-        given(loadReviewPort.getReviews(kaptCode, pageable))
-                .willReturn(Page.empty());
-        // When
-        Page<Review> reviews = sut.getReviews(kaptCode, pageable);
-
-        // Then
-        BDDAssertions.then(reviews.getContent())
-                .hasSize(0);
-    }
-
 
 }

--- a/src/test/java/com/zipte/platform/server/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/ReviewServiceTest.java
@@ -10,12 +10,16 @@ import com.zipte.platform.server.application.out.user.UserPort;
 import com.zipte.platform.server.domain.review.Review;
 import com.zipte.platform.server.domain.review.ReviewFixtures;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.NoSuchElementException;
 
@@ -151,5 +155,48 @@ class ReviewServiceTest {
                 .isInstanceOf(NoSuchElementException.class);
 
     }
+
+    @Test
+    @DisplayName(("[happy] 아파트에 대한 리뷰가 있는 경우, 정상 조회된다."))
+    void loadReviewByCode_happy() {
+
+        // Given
+        String kaptCode = "kaptCode";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Review> stubs = ReviewFixtures.pagedStubs(pageable);
+
+        given(loadEstatePort.checkExistingByCode(kaptCode))
+                .willReturn(true);
+        given(loadReviewPort.getReviews(kaptCode, pageable))
+                .willReturn(stubs);
+
+        // When
+        Page<Review> reviews = sut.getReviews(kaptCode, pageable);
+
+        // Then
+        BDDAssertions.then(reviews.getContent())
+                .hasSize(2);
+    }
+
+    @Test
+    @DisplayName(("[edge] 아파트에 대한 리뷰가 없는 경우, 0개의 리뷰가 조회된다.."))
+    void loadReviewByCode_bad() {
+
+        // Given
+        String kaptCode = "kaptCode";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        given(loadEstatePort.checkExistingByCode(kaptCode)).willReturn(true);
+        given(loadReviewPort.getReviews(kaptCode, pageable))
+                .willReturn(Page.empty());
+        // When
+        Page<Review> reviews = sut.getReviews(kaptCode, pageable);
+
+        // Then
+        BDDAssertions.then(reviews.getContent())
+                .hasSize(0);
+    }
+
 
 }

--- a/src/test/java/com/zipte/platform/server/domain/review/ReviewFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/review/ReviewFixtures.java
@@ -1,6 +1,11 @@
 package com.zipte.platform.server.domain.review;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ReviewFixtures {
     public static Review stub(Long id) {
@@ -30,4 +35,13 @@ public class ReviewFixtures {
                 .build();
 
     }
+
+    public static Page<Review> pagedStubs(Pageable pageable) {
+        List<Review> reviews = List.of(
+                stub(1L),
+                anotherStub(2L)
+        );
+        return new PageImpl<>(reviews, pageable, reviews.size());
+    }
 }
+


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->


## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 아파트 리뷰 조회 시, 존재하지 않는 아파트 코드에 대해 오류 메시지를 반환하도록 검증이 추가되었습니다.
	- 동일 사용자의 중복 리뷰 작성 시 오류가 발생하도록 개선되었습니다.
	- 리뷰 삭제 시 사용자와 리뷰 소유자 일치 여부를 검증하여 권한 없는 삭제를 방지합니다.

- **테스트**
	- 리뷰 생성, 조회, 삭제에 대한 정상 및 예외 케이스를 세분화하여 검증하는 테스트가 추가 및 리팩토링되었습니다.
	- 테스트용 리뷰 데이터를 페이지 형태로 제공하는 유틸리티 메서드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->