### PR TITLE
✨ feat/ZIP-63 : Redis 기반 최초 로그인 수정

### DIFF
--- a/src/main/java/com/zipte/platform/core/config/SecurityConfig.java
+++ b/src/main/java/com/zipte/platform/core/config/SecurityConfig.java
@@ -31,12 +31,6 @@ public class SecurityConfig {
     private final RequestMatcherHolder requestMatcherHolder;
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers("/login?error", "/error", "/favicon.ico");
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // rest api 설정
@@ -47,7 +41,7 @@ public class SecurityConfig {
                 .headers(c -> c.frameOptions(
                         HeadersConfigurer.FrameOptionsConfig::disable).disable()) // X-Frame-Options 비활성화
                 .sessionManagement(c ->
-                        c.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)) // 세션 필요한 경우 사용
+                        c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 필요한 경우 사용
 
                 // request 인증, 인가 설정
                 .authorizeHttpRequests(request -> request
@@ -57,7 +51,7 @@ public class SecurityConfig {
                         .hasAnyAuthority(MEMBER.getRole(), ADMIN.getRole())
                         .requestMatchers(requestMatcherHolder.getRequestMatchersByMinRole(ADMIN))
                         .hasAnyAuthority(ADMIN.getRole())
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
 
                 // oauth2 설정

--- a/src/main/java/com/zipte/platform/core/response/ErrorCode.java
+++ b/src/main/java/com/zipte/platform/core/response/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     /// 유저 관련
     NOT_USER(1000, HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다."),
+    FIRST_LOGIN(1200,HttpStatus.NOT_FOUND,"최초 로그인유저이기에 추가정보기입이 필요합니다."),
 
     /// 부동산 관련
     NOT_ESTATE(2000, HttpStatus.NOT_FOUND, "해당하는 부동산이 존재하지 않습니다."),

--- a/src/main/java/com/zipte/platform/security/jwt/handler/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zipte/platform/security/jwt/handler/JwtAuthenticationFilter.java
@@ -64,8 +64,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
 
-        return requestMatcherHolder.getRequestMatchersByMinRole(null)
+        boolean shouldSkip = requestMatcherHolder.getRequestMatchersByMinRole(null)
                 .matches(request);
+
+        log.info("요청 URL: {} | 필터 생략 여부: {}", request.getRequestURI(), shouldSkip);
+
+        return shouldSkip;
     }
 
 }

--- a/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
+++ b/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
@@ -23,14 +23,13 @@ public class RequestMatcherHolder {
             // auth
             new RequestInfo(GET, "/", null),
             new RequestInfo(POST, "/login/**", null),
-            new RequestInfo(GET, "/api/v1/oauth2/session-user", null),
             new RequestInfo(POST, "/api/v1/oauth2", null),
-            new RequestInfo(POST, "/api/v1/reissue", UserRole.MEMBER),
+            new RequestInfo(GET, "/api/v1/oauth2/temp-user/**", null),
+            new RequestInfo(POST, "/api/v1/signup/", null),
 
             // user
-            new RequestInfo(POST, "/api/v1/signup", null),
+            new RequestInfo(POST, "/api/v1/reissue/", UserRole.MEMBER),
             new RequestInfo(GET, "/api/v1/users/**", UserRole.MEMBER),
-            new RequestInfo(POST, "/signup", null),
 
             // admin
             new RequestInfo(GET, "/api/member/**", UserRole.MEMBER),
@@ -40,8 +39,21 @@ public class RequestMatcherHolder {
             new RequestInfo(GET, "/docs/**", null),
             new RequestInfo(GET, "/*.ico", null),
             new RequestInfo(GET, "/resources/**", null),
-            new RequestInfo(GET, "/error", null)
+            new RequestInfo(GET, "/index.html", null),
+            new RequestInfo(GET, "/error", null),
+
+            // Swagger UI 및 API 문서 관련 요청
+            new RequestInfo(GET, "/swagger-ui/**", null),
+            new RequestInfo(GET, "/v3/api-docs/**", null),
+            new RequestInfo(GET, "/swagger-resources/**", null),
+            new RequestInfo(GET, "/webjars/**", null),
+
+            // 정적 아이콘 요청
+            new RequestInfo(GET, "/favicon.ico", null),
+            new RequestInfo(GET, "/apple-touch-icon.png", null)
+
     );
+
     private final ConcurrentHashMap<String, RequestMatcher> reqMatcherCacheMap = new ConcurrentHashMap<>();
 
     /**

--- a/src/main/java/com/zipte/platform/security/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/zipte/platform/security/oauth2/handler/OAuth2FailureHandler.java
@@ -1,32 +1,63 @@
 package com.zipte.platform.security.oauth2.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zipte.platform.security.oauth2.handler.exception.RedirectToSignupException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
 
 @Log4j2
 @Component
+@RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
     private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
 
         /// 최초 로그인한 유저의 경우
-        if (exception instanceof RedirectToSignupException) {
+        if (exception instanceof RedirectToSignupException redirect) {
 
-            // 프런트의 회원가입 페이지로 리디렉션
-            redirectStrategy.sendRedirect(request, response, "http://localhost:3000/signup");
+            /// 유저 정보 가져오기
+
+            Map<String, Object> attributes = redirect.getOAuth2UserAttributes();
+            String provider = redirect.getProvider();
+
+            /// UUID 기반 state 생성
+            String state = UUID.randomUUID().toString();
+
+            /// provider 넣기
+            Map<String, Object> stringObjectMap = new java.util.HashMap<>(attributes);
+            stringObjectMap.put("provider", provider);
+
+            /// 사용자 임시 정보 Redis에 저장 (5~10분 TTL 권장)
+            redisTemplate.opsForValue().set("OAUTH2:TEMP:" + state, objectMapper.writeValueAsString(stringObjectMap), Duration.ofMinutes(5));
+
+            /// 프론트에 state로 리다이렉트
+            String redirectUrl = UriComponentsBuilder
+                    .fromUriString("http://localhost:3000/signup")
+                    .queryParam("state", state)
+                    .build()
+                    .toUriString();
+
+            redirectStrategy.sendRedirect(request, response, redirectUrl);
         }
         else {
             response.sendRedirect("/login?error");

--- a/src/main/java/com/zipte/platform/security/oauth2/handler/exception/RedirectToSignupException.java
+++ b/src/main/java/com/zipte/platform/security/oauth2/handler/exception/RedirectToSignupException.java
@@ -1,9 +1,21 @@
 package com.zipte.platform.security.oauth2.handler.exception;
 
+import com.zipte.platform.core.response.ErrorCode;
+import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 
+import java.util.Map;
+
+@Getter
 public class RedirectToSignupException extends AuthenticationException {
-    public RedirectToSignupException(String message) {
-        super(message);
+
+    private final Map<String, Object> oAuth2UserAttributes;
+    private final String provider;
+
+    public RedirectToSignupException(Map<String, Object> oAuth2UserAttributes, String provider) {
+
+        super(ErrorCode.FIRST_LOGIN.getMessage());
+        this.oAuth2UserAttributes = oAuth2UserAttributes;
+        this.provider = provider;
     }
 }

--- a/src/main/java/com/zipte/platform/security/oauth2/service/OAuth2UserService.java
+++ b/src/main/java/com/zipte/platform/security/oauth2/service/OAuth2UserService.java
@@ -2,20 +2,16 @@ package com.zipte.platform.security.oauth2.service;
 
 import com.zipte.platform.security.oauth2.domain.OAuth2UserInfo;
 import com.zipte.platform.security.oauth2.domain.PrincipalDetails;
-import com.zipte.platform.security.oauth2.domain.google.GoogleUserInfo;
-import com.zipte.platform.security.oauth2.domain.kakao.KakaoUserInfo;
-import com.zipte.platform.security.oauth2.domain.naver.NaverUserInfo;
 import com.zipte.platform.security.oauth2.handler.exception.RedirectToSignupException;
+import com.zipte.platform.security.oauth2.util.OAuth2UserInfoFactory;
 import com.zipte.platform.server.application.out.user.UserPort;
 import com.zipte.platform.server.domain.user.OAuthProvider;
 import com.zipte.platform.server.domain.user.User;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +26,6 @@ import java.util.Optional;
 public class OAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserPort userPort;
-    private final HttpSession session;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -50,7 +45,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
         // OAuth2를 바탕으로 정보 생성
         OAuth2UserInfo userInfo = null;
 
-        userInfo = getOAuth2UserInfo(registrationId, oAuth2UserAttributes);
+        userInfo = OAuth2UserInfoFactory.create(registrationId, oAuth2UserAttributes);
         log.info("userInfo: {}", userInfo.getProvider());
         log.info("userInfo: {}", userInfo.getUserName());
         log.info("userInfo: {}", userInfo.getEmail());
@@ -65,35 +60,10 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
 
             return PrincipalDetails.of(user, oAuth2UserAttributes);
 
-        }
-        else{
-            // 존재하지 않는다면, 세션에 저장 후
+        } else {
             // 프런트에게 해당 정보를 넘겨주면서 회원가입을 진행한다.
-            session.setAttribute("user", userInfo);
-            throw new RedirectToSignupException("기존 OAuth2 유저가 존재하지 않기 때문에, 새롭게 회원가입이 필요합니다.");
+            throw new RedirectToSignupException(oAuth2UserAttributes, userInfo.getProvider());
         }
 
-    }
-
-    /// 내부 함수
-    private OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> oAuth2UserAttributes) {
-        OAuth2UserInfo userInfo;
-        // registrationId에 따라서 유저 정보 dto 생성
-        if (registrationId.equals("google")) {
-            userInfo = new GoogleUserInfo(oAuth2UserAttributes);
-        }
-
-        else if (registrationId.equals("kakao")) {
-            userInfo = new KakaoUserInfo(oAuth2UserAttributes);
-        }
-
-        else if (registrationId.equals("naver")) {
-            userInfo = new NaverUserInfo(oAuth2UserAttributes);
-        }
-
-        else {
-            throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
-        }
-        return userInfo;
     }
 }

--- a/src/main/java/com/zipte/platform/security/oauth2/util/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/zipte/platform/security/oauth2/util/OAuth2UserInfoFactory.java
@@ -1,0 +1,32 @@
+package com.zipte.platform.security.oauth2.util;
+
+import com.zipte.platform.security.oauth2.domain.OAuth2UserInfo;
+import com.zipte.platform.security.oauth2.domain.google.GoogleUserInfo;
+import com.zipte.platform.security.oauth2.domain.kakao.KakaoUserInfo;
+import com.zipte.platform.security.oauth2.domain.naver.NaverUserInfo;
+
+import java.util.Map;
+
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo create(String registrationId, Map<String, Object> attributes) {
+        OAuth2UserInfo userInfo;
+
+        switch (registrationId.toUpperCase()) {
+            case "KAKAO":
+                userInfo = new KakaoUserInfo(attributes);
+                break;
+            case "NAVER":
+                userInfo = new NaverUserInfo(attributes);
+                break;
+            case "GOOGLE":
+                userInfo = new GoogleUserInfo(attributes);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown provider: " + registrationId);
+        }
+        return userInfo;
+    }
+
+}

--- a/src/main/java/com/zipte/platform/server/adapter/in/web/AuthController.java
+++ b/src/main/java/com/zipte/platform/server/adapter/in/web/AuthController.java
@@ -1,19 +1,25 @@
 package com.zipte.platform.server.adapter.in.web;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zipte.platform.core.response.ApiResponse;
 import com.zipte.platform.security.jwt.service.JwtTokenUseCase;
 import com.zipte.platform.security.oauth2.domain.OAuth2UserInfo;
+import com.zipte.platform.security.oauth2.util.OAuth2UserInfoFactory;
 import com.zipte.platform.server.adapter.in.web.dto.request.UserRegisterRequest;
 import com.zipte.platform.server.adapter.in.web.dto.response.OAuth2UserInfoResponse;
 import com.zipte.platform.server.adapter.in.web.swagger.AuthAPiSpec;
 import com.zipte.platform.server.application.in.auth.AuthUserUseCase;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -24,13 +30,27 @@ public class AuthController implements AuthAPiSpec {
     // 토큰 재발급
     private final AuthUserUseCase authService;
     private final JwtTokenUseCase tokenService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
 
-    @GetMapping("/session-user")
-    public ApiResponse<OAuth2UserInfoResponse> getSessionUser(HttpSession session) {
 
-        OAuth2UserInfo userInfo = (OAuth2UserInfo) session.getAttribute("user");
+    @GetMapping("/temp-user/{state}")
+    public ApiResponse<OAuth2UserInfoResponse> getTempUser(@PathVariable String state) throws JsonProcessingException {
+
+        /// 값 읽기
+        String key = "OAUTH2:TEMP:" + state;
+        String json = redisTemplate.opsForValue().get(key);
+
+        Map<String, Object> attributes = objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        String provider = (String) attributes.get("provider");
+
+        // Map을 넘겨서 OAuth2UserInfo 생성
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.create(provider, attributes);
+
         OAuth2UserInfoResponse response = OAuth2UserInfoResponse.from(userInfo);
-        log.info("로그 {}", response.toString());
+
+        log.info("로그 {}", response);
+
         return ApiResponse.ok(response);
     }
 

--- a/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/AuthAPiSpec.java
+++ b/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/AuthAPiSpec.java
@@ -1,5 +1,6 @@
 package com.zipte.platform.server.adapter.in.web.swagger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.zipte.platform.core.response.ApiResponse;
 import com.zipte.platform.server.adapter.in.web.dto.request.UserRegisterRequest;
 import com.zipte.platform.server.adapter.in.web.dto.response.OAuth2UserInfoResponse;
@@ -10,9 +11,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "유저 인증/인가 API", description = "유저 로그인/회원가입 관련 API")
@@ -40,7 +41,9 @@ public interface AuthAPiSpec {
             summary = "최초 회원가입 유저 조회",
             description = "세션을 통해 최초 회원가입 유저의 소셜로그인 정보를 조회합니다."
     )
-    ApiResponse<OAuth2UserInfoResponse> getSessionUser(HttpSession session);
+    ApiResponse<OAuth2UserInfoResponse> getTempUser(
+
+            @PathVariable String state) throws JsonProcessingException;
 
     @Operation(
             summary = "Jwt 토큰 재발급",


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->


## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - OAuth2 첫 로그인 시 추가 정보 입력이 필요한 사용자를 위한 에러 코드가 추가되었습니다.
    - OAuth2 인증 실패 시, 사용자 정보를 임시로 Redis에 저장하고 프론트엔드 회원가입 페이지로 안전하게 리다이렉트됩니다.
    - 임시 사용자 정보를 state 파라미터로 조회하는 신규 API가 도입되었습니다.

- **버그 수정**
    - 인증 및 세션 관리 정책이 무상태(Stateless)로 강화되어 보안성이 향상되었습니다.
    - 인증되지 않은 요청에 대한 접근 제한이 강화되었습니다.

- **리팩터링**
    - OAuth2 사용자 정보 생성 로직이 팩토리 패턴으로 통합되어 유지보수가 용이해졌습니다.
    - 세션 기반 사용자 정보 저장 방식이 Redis 기반으로 개선되었습니다.

- **문서화**
    - 인증 관련 API 명세가 임시 사용자 정보 조회 방식으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->