### PR TITLE
♻️ refactor/ZIP-39 : 유저 및 아파트 가격 API 이름 수정

### DIFF
--- a/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/AuthAPiSpec.java
+++ b/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/AuthAPiSpec.java
@@ -16,7 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "유저 인증/인가 API", description = "유저 로그인/회원가입 관련 API")
+@Tag(name = "유저 인증/인가 API", description = "유저 로그인/회원가입 관련 API / 스웨거보단 로컬에서 직접 테스트 해야한다.")
 public interface AuthAPiSpec {
 
     @Operation(
@@ -95,3 +95,4 @@ public interface AuthAPiSpec {
 
 
 }
+

--- a/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/EstatePriceApiSpec.java
+++ b/src/main/java/com/zipte/platform/server/adapter/in/web/swagger/EstatePriceApiSpec.java
@@ -15,8 +15,8 @@ public interface EstatePriceApiSpec {
 
 
     @Operation(
-            summary = "지역 가격 정보 조회",
-            description = "지역 코드를 통해 가격 정보를 조회합니다."
+            summary = "아파트 가격 정보 조회",
+            description = "아파트 코드를 통해 가격 정보를 조회합니다."
     )
     ApiResponse<List<EstatePriceListResponse>> getPrice(
             @Parameter(description = "아파트 코드", required = true, example = "A46392821")
@@ -24,8 +24,8 @@ public interface EstatePriceApiSpec {
 
 
     @Operation(
-            summary = "지역 가격 정보 조회",
-            description = "지역 코드와 평수를 통해 가격 정보를 조회합니다."
+            summary = "아파트 가격 정보 조회",
+            description = "아파트 코드와 평수를 통해 가격 정보를 조회합니다."
     )
     ApiResponse<List<EstatePriceListResponse>> getPriceByCodeAndArea(
             @Parameter(description = "아파트 코드", required = true, example = "A46392821")
@@ -35,3 +35,4 @@ public interface EstatePriceApiSpec {
             @RequestParam double area);
 
 }
+


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
♻️ refactor/ZIP-39 : 유저 및 아파트 가격 API 이름 수정

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
  - 인증 API의 Swagger 문서 설명이 업데이트되었습니다.
  - 부동산 시세 API의 문서에서 "지역"이 "아파트"로 변경되어, 아파트 코드 기반으로 쿼리함을 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->