### PR TITLE
✨ feat/ZIP-58-Auth : 인가 관련 부분 수정

### DIFF
--- a/src/main/java/com/zipte/platform/core/config/SecurityConfig.java
+++ b/src/main/java/com/zipte/platform/core/config/SecurityConfig.java
@@ -9,12 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import static com.zipte.platform.server.domain.user.UserRole.ADMIN;
 import static com.zipte.platform.server.domain.user.UserRole.MEMBER;
@@ -34,14 +34,16 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // rest api 설정
-                .csrf(AbstractHttpConfigurer::disable) // csrf 비활성화 -> cookie를 사용하지 않으면 꺼도 된다. (cookie를 사용할 경우 httpOnly(XSS 방어), sameSite(CSRF 방어)로 방어해야 한다.)
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                )
                 .httpBasic(AbstractHttpConfigurer::disable) // 기본 인증 로그인 비활성화
                 .formLogin(AbstractHttpConfigurer::disable) // 기본 login form 비활성화
                 .logout(AbstractHttpConfigurer::disable) // 기본 logout 비활성화
                 .headers(c -> c.frameOptions(
                         HeadersConfigurer.FrameOptionsConfig::disable).disable()) // X-Frame-Options 비활성화
                 .sessionManagement(c ->
-                        c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 필요한 경우 사용
+                        c.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)) // 세션 필요한 경우 사용
 
                 // request 인증, 인가 설정
                 .authorizeHttpRequests(request -> request

--- a/src/main/java/com/zipte/platform/security/jwt/service/JwtTokenService.java
+++ b/src/main/java/com/zipte/platform/security/jwt/service/JwtTokenService.java
@@ -68,7 +68,7 @@ public class JwtTokenService implements JwtTokenUseCase {
                 .orElseThrow(() -> new NoSuchElementException("쿠키에 RefreshToken 존재하지 않습니다."));
 
         // 쿠키 validate 진행한다.
-        if (provider.validateToken(refreshToken)) {
+        if (!provider.validateToken(refreshToken)) {
             throw new SecurityException("유효하지 않은 토큰입니다.");
         };
 
@@ -101,7 +101,7 @@ public class JwtTokenService implements JwtTokenUseCase {
     private void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
         Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setHttpOnly(true);
-        cookie.setSecure(false);
+        cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge((int) REFRESH_TOKEN_EXPIRATION_TIME);
         response.addCookie(cookie);

--- a/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
+++ b/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
@@ -22,6 +22,8 @@ public class RequestMatcherHolder {
             // 공통
             new RequestInfo(OPTIONS, "/**", null),
             new RequestInfo(GET, "/", null),
+            new RequestInfo(GET, "/login", null),
+            new RequestInfo(POST, "/error", null),
 
             // auth
             new RequestInfo(POST, "/api/v1/oauth2", null),

--- a/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
+++ b/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
@@ -28,10 +28,9 @@ public class RequestMatcherHolder {
             // auth
             new RequestInfo(POST, "/api/v1/oauth2", null),
             new RequestInfo(GET, "/api/v1/oauth2/temp-user/**", null),
-            new RequestInfo(POST, "/api/v1/oauth2/reissue", null),
+            new RequestInfo(POST, "/api/v1/oauth2/reissue", UserRole.MEMBER),
 
             // user
-            new RequestInfo(POST, "/api/v1/reissue/", UserRole.MEMBER),
             new RequestInfo(GET, "/api/v1/users/**", UserRole.MEMBER),
 
             // admin

--- a/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
+++ b/src/main/java/com/zipte/platform/security/jwt/util/RequestMatcherHolder.java
@@ -26,7 +26,7 @@ public class RequestMatcherHolder {
             // auth
             new RequestInfo(POST, "/api/v1/oauth2", null),
             new RequestInfo(GET, "/api/v1/oauth2/temp-user/**", null),
-            new RequestInfo(GET, "/api/v1/oauth2/reissue", null),
+            new RequestInfo(POST, "/api/v1/oauth2/reissue", null),
 
             // user
             new RequestInfo(POST, "/api/v1/reissue/", UserRole.MEMBER),

--- a/src/main/java/com/zipte/platform/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/zipte/platform/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -2,7 +2,7 @@ package com.zipte.platform.security.oauth2.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zipte.platform.core.response.ApiResponse;
-import com.zipte.platform.security.jwt.service.JwtTokenService;
+import com.zipte.platform.security.jwt.service.JwtTokenUseCase;
 import com.zipte.platform.security.oauth2.domain.PrincipalDetails;
 import com.zipte.platform.server.adapter.in.web.dto.response.UserLoginResponse;
 import com.zipte.platform.server.domain.user.User;
@@ -22,7 +22,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtTokenService tokenService;
+    private final JwtTokenUseCase tokenService;
     private final ObjectMapper objectMapper;
 
     /*

--- a/src/main/java/com/zipte/platform/server/application/service/LogoutService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/LogoutService.java
@@ -16,7 +16,7 @@ public class LogoutService implements LogoutUserUseCase {
     private final JwtTokenUseCase tokenService;
 
     /// 생성자
-    public LogoutService(JwtTokenService tokenService) {
+    public LogoutService(JwtTokenUseCase tokenService) {
         this.tokenService = tokenService;
     }
 


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
✨ feat/ZIP-58-Auth : 인가 관련 부분 수정

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 리프레시 토큰 검증 로직이 올바르게 동작하도록 수정되었습니다.
  - 리프레시 토큰 쿠키가 HTTPS에서만 전송되도록 보안 설정이 강화되었습니다.

- **보안 개선**
  - CSRF 보호가 활성화되어 토큰이 쿠키에 저장됩니다.
  - 세션 관리 정책이 필요 시 세션이 생성될 수 있도록 변경되었습니다.

- **접근 제어 변경**
  - 일부 엔드포인트의 접근 권한 및 HTTP 메서드가 조정되었습니다.

- **리팩토링**
  - 인증 및 로그아웃 관련 서비스의 내부 의존성 타입이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->