### PR TITLE
✨ feat/ZIP-60 : Q&A 관련 알림 기능 추가

### DIFF
--- a/src/main/java/com/zipte/platform/core/response/ErrorCode.java
+++ b/src/main/java/com/zipte/platform/core/response/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
 
     /// 질문 관련
     NOT_QUESTION(7000, HttpStatus.NOT_FOUND, "해당하는 질문이 존재하지 않습니다"),
+    NOT_ANSWER(7001, HttpStatus.NOT_FOUND, "해당하는 답변이 존재하지 않습니다"),
     BAD_REQUEST_DELETE_QUESTION(7010, HttpStatus.BAD_REQUEST, "본인이 등록하지 않은 질문을 삭제할 수 없습니다."),
     BAD_REQUEST_DELETE_ANSWER(7011, HttpStatus.BAD_REQUEST, "본인이 등록하지 않은 질문을 삭제할 수 없습니다.");
 

--- a/src/main/java/com/zipte/platform/server/adapter/out/AnswerNotificationPersistenceAdapter.java
+++ b/src/main/java/com/zipte/platform/server/adapter/out/AnswerNotificationPersistenceAdapter.java
@@ -29,10 +29,8 @@ public class AnswerNotificationPersistenceAdapter implements SaveAnswerNotificat
 
 
     @Override
-    public void deleteAnswerNotification(Long answerId) {
-        AnswerNotificationDocument document = repository.findByAnswerId(answerId)
-                .orElseThrow(() -> new EntityNotFoundException("값이 존재하지않습니다"));
+    public void deleteAnswerNotification(String id) {
 
-        repository.deleteById(document.getId());
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/com/zipte/platform/server/application/in/task/AnswerNotificationTask.java
+++ b/src/main/java/com/zipte/platform/server/application/in/task/AnswerNotificationTask.java
@@ -7,6 +7,7 @@ public interface AnswerNotificationTask {
 
     void createNotification(Answer answer);
 
-    void removeNotification(Answer answer);
+    void removeNotification(Long answerId);
+
 
 }

--- a/src/main/java/com/zipte/platform/server/application/out/notification/answer/DeleteAnswerNotificationPort.java
+++ b/src/main/java/com/zipte/platform/server/application/out/notification/answer/DeleteAnswerNotificationPort.java
@@ -2,7 +2,7 @@ package com.zipte.platform.server.application.out.notification.answer;
 
 public interface DeleteAnswerNotificationPort {
 
-    void deleteAnswerNotification(Long answerId);
+    void deleteAnswerNotification(String id);
 
 
 }

--- a/src/main/java/com/zipte/platform/server/application/service/AnswerService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/AnswerService.java
@@ -3,6 +3,7 @@ package com.zipte.platform.server.application.service;
 import com.zipte.platform.core.response.ErrorCode;
 import com.zipte.platform.server.adapter.in.web.dto.request.AnswerRequest;
 import com.zipte.platform.server.application.in.community.AnswerUseCase;
+import com.zipte.platform.server.application.in.task.AnswerNotificationTask;
 import com.zipte.platform.server.application.out.community.AnswerPort;
 import com.zipte.platform.server.application.out.community.QuestionPort;
 import com.zipte.platform.server.application.out.user.UserPort;
@@ -24,6 +25,9 @@ public class AnswerService implements AnswerUseCase {
     private final UserPort userPort;
     private final QuestionPort questionPort;
 
+    /// 알림센터 의존성
+    private final AnswerNotificationTask notificationService;
+
     @Override
     public Answer createAnswer(AnswerRequest request) {
 
@@ -43,7 +47,12 @@ public class AnswerService implements AnswerUseCase {
         Answer answer = Answer.of(request.getUserId(), request.getQuestionId(), request.getContent());
 
         /// 저장하기
-        return answerPort.saveAnswer(answer);
+        Answer saved = answerPort.saveAnswer(answer);
+
+        /// 알림 생성하기
+        notificationService.createNotification(saved);
+
+        return saved;
     }
 
     @Override
@@ -63,6 +72,9 @@ public class AnswerService implements AnswerUseCase {
 
         /// 삭제하기
         answerPort.deleteAnswerById(id);
+
+        /// 알림 제거하기
+        notificationService.removeNotification(id);
 
     }
 

--- a/src/main/java/com/zipte/platform/server/application/service/task/AnswerNotificationService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/task/AnswerNotificationService.java
@@ -4,7 +4,6 @@ import com.zipte.platform.core.response.ErrorCode;
 import com.zipte.platform.core.util.NotificationIdGenerator;
 import com.zipte.platform.server.adapter.out.mongo.notification.base.NotificationType;
 import com.zipte.platform.server.application.in.task.AnswerNotificationTask;
-import com.zipte.platform.server.application.out.community.AnswerPort;
 import com.zipte.platform.server.application.out.community.QuestionPort;
 import com.zipte.platform.server.application.out.notification.LoadNotificationPort;
 import com.zipte.platform.server.application.out.notification.answer.DeleteAnswerNotificationPort;
@@ -31,7 +30,6 @@ public class AnswerNotificationService implements AnswerNotificationTask {
 
     /// 의존성
     private final QuestionPort questionPort;
-    private final AnswerPort answerPort;
 
     @Override
     public void createNotification(Answer answer) {

--- a/src/main/java/com/zipte/platform/server/application/service/task/AnswerNotificationService.java
+++ b/src/main/java/com/zipte/platform/server/application/service/task/AnswerNotificationService.java
@@ -4,7 +4,9 @@ import com.zipte.platform.core.response.ErrorCode;
 import com.zipte.platform.core.util.NotificationIdGenerator;
 import com.zipte.platform.server.adapter.out.mongo.notification.base.NotificationType;
 import com.zipte.platform.server.application.in.task.AnswerNotificationTask;
+import com.zipte.platform.server.application.out.community.AnswerPort;
 import com.zipte.platform.server.application.out.community.QuestionPort;
+import com.zipte.platform.server.application.out.notification.LoadNotificationPort;
 import com.zipte.platform.server.application.out.notification.answer.DeleteAnswerNotificationPort;
 import com.zipte.platform.server.application.out.notification.answer.SaveAnswerNotificationPort;
 import com.zipte.platform.server.domain.community.Answer;
@@ -24,10 +26,12 @@ import java.util.Objects;
 public class AnswerNotificationService implements AnswerNotificationTask {
 
     private final SaveAnswerNotificationPort savePort;
+    private final LoadNotificationPort loadPort;
     private final DeleteAnswerNotificationPort deletePort;
 
     /// 의존성
     private final QuestionPort questionPort;
+    private final AnswerPort answerPort;
 
     @Override
     public void createNotification(Answer answer) {
@@ -51,7 +55,13 @@ public class AnswerNotificationService implements AnswerNotificationTask {
     }
 
     @Override
-    public void removeNotification(Answer answer) {
+    public void removeNotification(Long answerId) {
+
+        /// 예외처리
+        AnswerNotification answer = loadPort.loadAnswerNotification(answerId)
+                .orElseThrow(() -> new NoSuchElementException(ErrorCode.NOT_ANSWER.getMessage()));
+
+        /// 삭제
         deletePort.deleteAnswerNotification(answer.getId());
     }
 

--- a/src/test/java/com/zipte/platform/server/application/service/AnswerServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/AnswerServiceTest.java
@@ -1,6 +1,7 @@
 package com.zipte.platform.server.application.service;
 
 import com.zipte.platform.server.adapter.in.web.dto.request.AnswerRequest;
+import com.zipte.platform.server.application.in.task.AnswerNotificationTask;
 import com.zipte.platform.server.application.out.community.AnswerPort;
 import com.zipte.platform.server.application.out.community.QuestionPort;
 import com.zipte.platform.server.application.out.user.UserPort;
@@ -32,6 +33,9 @@ class AnswerServiceTest {
 
     @Mock
     private QuestionPort questionPort;
+
+    @Mock
+    private AnswerNotificationTask answerNotificationTask;
 
     @InjectMocks
     private AnswerService sut;
@@ -71,6 +75,9 @@ class AnswerServiceTest {
                     .isNotNull()
                     .hasFieldOrPropertyWithValue("userId", userId)
                     .hasFieldOrPropertyWithValue("questionId", questionId);
+
+            verify(answerNotificationTask).createNotification(result);
+
         }
 
 
@@ -140,6 +147,8 @@ class AnswerServiceTest {
 
             // Then
             verify(answerPort).deleteAnswerById(answerId);
+            verify(answerNotificationTask).removeNotification(answerId);
+
         }
 
         @Test

--- a/src/test/java/com/zipte/platform/server/application/service/task/AnswerNotificationServiceTest.java
+++ b/src/test/java/com/zipte/platform/server/application/service/task/AnswerNotificationServiceTest.java
@@ -1,0 +1,127 @@
+package com.zipte.platform.server.application.service.task;
+
+import com.zipte.platform.server.application.out.community.QuestionPort;
+import com.zipte.platform.server.application.out.notification.LoadNotificationPort;
+import com.zipte.platform.server.application.out.notification.answer.DeleteAnswerNotificationPort;
+import com.zipte.platform.server.application.out.notification.answer.SaveAnswerNotificationPort;
+import com.zipte.platform.server.domain.community.Answer;
+import com.zipte.platform.server.domain.notification.AnswerNotification;
+import com.zipte.platform.server.domain.notification.AnswerNotificationFixtures;
+import com.zipte.platform.server.domain.qa.AnswerFixtures;
+import com.zipte.platform.server.domain.qa.QuestionFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class AnswerNotificationServiceTest {
+
+    @Mock
+    private SaveAnswerNotificationPort savePort;
+
+    @Mock
+    private LoadNotificationPort loadPort;
+
+    @Mock
+    private DeleteAnswerNotificationPort deletePort;
+
+    @Mock
+    private QuestionPort questionPort;
+
+
+    @InjectMocks
+    private AnswerNotificationService sut;
+
+    @Nested
+    @DisplayName("생성 관련 테스트")
+    class CreateTask {
+
+        @Test
+        @DisplayName("[happy] 다른 유저의 답변의 경우, 정상적인 알림 생성 됨")
+        void create_happy() {
+
+            // Given
+            Long questionUserId = 1L;
+            Long questionId = 5L;
+
+            Long answerId = 1L;
+            Long answerUserId = 100L;
+
+            Answer answer = AnswerFixtures.stub(answerUserId, questionId);
+
+            given(questionPort.loadQuestion(answer.getQuestionId()))
+                    .willReturn(Optional.of(QuestionFixtures.stub(questionUserId)));
+
+            given(savePort.saveNotification(any()))
+                    .willReturn(AnswerNotificationFixtures.stub(questionUserId, questionId, answerId, answerUserId));
+
+            // When
+            sut.createNotification(answer);
+
+            // Then
+            then(savePort).should()
+                    .saveNotification(any());
+
+        }
+
+
+        @Test
+        @DisplayName("[edge] 질문과 답변이 같은 유저가 작성한 경우, 알림 생성 되지않음 ")
+        void create_sameUser() {
+
+            // Given
+            Long questionId = 5L;
+            Long questionUserId = 1L;
+
+            Long answerUserId = 1L;
+
+            Answer answer = AnswerFixtures.stub(answerUserId, questionId);
+
+            given(questionPort.loadQuestion(answer.getQuestionId()))
+                    .willReturn(Optional.of(QuestionFixtures.stub(questionUserId)));
+            // When
+            sut.createNotification(answer);
+
+            // Then
+            then(savePort).shouldHaveNoInteractions();
+        }
+
+    }
+
+    @Nested
+    @DisplayName("삭제 관련 테스트")
+    class DeleteTask {
+
+        @Test
+        @DisplayName("알림 삭제 - 정상 케이스")
+        void deleteNotification() {
+            // Given
+            Long answerId = 10L;
+            String id = UUID.randomUUID().toString();
+
+            given(loadPort.loadAnswerNotification(answerId))
+                    .willReturn(Optional.of(AnswerNotificationFixtures.stub(id)));
+
+            // When
+            sut.removeNotification(answerId);
+
+            // Then
+            then(deletePort).should().deleteAnswerNotification(id);
+
+        }
+
+
+    }
+
+}

--- a/src/test/java/com/zipte/platform/server/domain/notification/AnswerNotificationFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/notification/AnswerNotificationFixtures.java
@@ -1,0 +1,45 @@
+package com.zipte.platform.server.domain.notification;
+
+import com.zipte.platform.server.adapter.out.mongo.notification.base.NotificationType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class AnswerNotificationFixtures {
+
+    public static AnswerNotification stub(String id) {
+
+        return AnswerNotification.of(
+                id,          // id
+                1L,                                     // userId
+                NotificationType.ANSWER,               // type (ENUM 값에 맞게 조정)
+                LocalDateTime.now().minusHours(1),     // occurredAt
+                LocalDateTime.now(),                   // createdAt
+                LocalDateTime.now(),                   // lastUpdatedAt
+                LocalDateTime.now(),                                   // deleteAt
+                2L,                                   // questionId
+                3L,                                   // writerId
+                4L,                                   // answerId
+                "이것은 테스트 알림입니다."             // content
+        );
+    }
+
+
+    public static AnswerNotification stub(Long userId, Long questionId, Long answerId, Long writerId) {
+
+        return AnswerNotification.of(
+                UUID.randomUUID().toString(),          // id
+                userId,                                     // userId
+                NotificationType.ANSWER,               // type (ENUM 값에 맞게 조정)
+                LocalDateTime.now().minusHours(1),     // occurredAt
+                LocalDateTime.now(),                   // createdAt
+                LocalDateTime.now(),                   // lastUpdatedAt
+                LocalDateTime.now(),                                   // deleteAt
+                questionId,                                   // questionId
+                writerId,                                   // writerId
+                answerId,                                   // answerId
+                "이것은 테스트 알림입니다."             // content
+        );
+    }
+
+}

--- a/src/test/java/com/zipte/platform/server/domain/qa/QuestionFixtures.java
+++ b/src/test/java/com/zipte/platform/server/domain/qa/QuestionFixtures.java
@@ -18,6 +18,20 @@ public class QuestionFixtures {
 
     }
 
+    public static Question stub(Long userId) {
+
+        return Question.builder()
+                .id(1L)
+                .userId(userId)
+                .kaptCode("kaptCode")
+                .title("title")
+                .content("content")
+                .statistics(QuestionStatisticsFixtures.stub())
+                .build();
+
+
+    }
+
     public static Question stub(Long userId, String kaptCode, String title, String content) {
 
         return Question.builder()


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
✨ feat/ZIP-60 : Q&A 관련 알림 기능 추가

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
<img width="1489" alt="스크린샷 2025-05-17 21 21 38" src="https://github.com/user-attachments/assets/1f4369bd-dc7a-415c-a8fc-9e76eb03f40b" />

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 답변이 존재하지 않을 때 표시되는 새로운 오류 메시지가 추가되었습니다.
	- 답변 생성 및 삭제 시 관련 알림이 자동으로 생성 및 삭제되도록 개선되었습니다.
- **버그 수정**
	- 답변 삭제 시 관련 알림이 함께 삭제되도록 개선되었습니다.
- **리팩터**
	- 답변 알림 삭제 및 관련 메서드의 파라미터 타입이 일관성 있게 변경되었습니다.
- **테스트**
	- 답변 알림 관련 서비스의 생성 및 삭제 기능에 대한 단위 테스트가 추가되었습니다.
	- 테스트용 답변 알림 및 질문 객체 생성용 픽스처가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->